### PR TITLE
I2c slave

### DIFF
--- a/cores/esp8266/core_esp8266_si2c.c
+++ b/cores/esp8266/core_esp8266_si2c.c
@@ -153,11 +153,11 @@ void twi_init(unsigned char sda, unsigned char scl)
   twi_scl = scl;
   pinMode(twi_sda, INPUT_PULLUP);
   pinMode(twi_scl, INPUT_PULLUP);
-  pinMode(2, OUTPUT);
-  pinMode(12, OUTPUT);
-  pinMode(14, OUTPUT);
-  pinMode(13, OUTPUT);
-  digitalWrite(2, HIGH);
+  //pinMode(2, OUTPUT);
+  //pinMode(12, OUTPUT);
+  //pinMode(14, OUTPUT);
+  //pinMode(13, OUTPUT);
+  //digitalWrite(2, HIGH);
   twi_setClock(100000);
   twi_setClockStretchLimit(230); // default value is 230 uS
   
@@ -396,7 +396,7 @@ void ICACHE_RAM_ATTR twi_releaseBus(void)
 
 void ICACHE_RAM_ATTR onTimer(void *timer_arg)
 {
-	digitalWrite(13, HIGH);
+	//digitalWrite(13, HIGH);
 	twi_releaseBus();
 	//ets_timer_disarm(&timer);
 
@@ -404,12 +404,12 @@ void ICACHE_RAM_ATTR onTimer(void *timer_arg)
 	twi_onTwipEvent(twip_status);
 	twip_mode = TWIPM_WAIT;
 	twip_state = TWIP_BUS_ERR;
-	digitalWrite(13, LOW);
+	//digitalWrite(13, LOW);
 }
 
 static void eventTask(ETSEvent *e)
 {
-	digitalWrite(14, HIGH);
+	//digitalWrite(14, HIGH);
 	
 	if (e == NULL) {
 		return;
@@ -432,17 +432,18 @@ static void eventTask(ETSEvent *e)
 			break;
 
 		case TWI_SIG_RX:
+			// ack future responses and leave slave receiver state
 			twi_releaseBus();
 			twi_onSlaveReceive(twi_rxBuffer, e->par);
 			break;
 	}
 
-	digitalWrite(14, LOW);
+	//digitalWrite(14, LOW);
 }
 
 void ICACHE_RAM_ATTR twi_onTwipEvent(uint8_t status)
 {
-  digitalWrite(13, HIGH);
+  //digitalWrite(13, HIGH);
   //switch(TW_STATUS){
   switch(status) {
 #if 0
@@ -544,14 +545,11 @@ void ICACHE_RAM_ATTR twi_onTwipEvent(uint8_t status)
       }
       break;
     case TW_SR_STOP: // stop or repeated start condition received
-      // ack future responses and leave slave receiver state
-      //BH twi_releaseBus();
       // put a null char after data if there's room
       if(twi_rxBufferIndex < TWI_BUFFER_LENGTH){
         twi_rxBuffer[twi_rxBufferIndex] = '\0';
       }
-      // callback to user defined callback
-      //twi_onSlaveReceive(twi_rxBuffer, twi_rxBufferIndex);
+      // callback to user-defined callback over event task to allow for non-RAM-residing code
 	  //twi_rxBufferLock = true; // This may be necessary
 	  ets_post(EVENTTASK_QUEUE_PRIO, TWI_SIG_RX, twi_rxBufferIndex);
 
@@ -574,22 +572,13 @@ void ICACHE_RAM_ATTR twi_onTwipEvent(uint8_t status)
       twi_txBufferIndex = 0;
       // set tx buffer length to be zero, to verify if user changes it
       twi_txBufferLength = 0;
+      // callback to user-defined callback over event task to allow for non-RAM-residing code
       // request for txBuffer to be filled and length to be set
       // note: user must call twi_transmit(bytes, length) to do this
-      //twi_onSlaveTransmit();
 	  ets_post(EVENTTASK_QUEUE_PRIO, TWI_SIG_TX, 0);
-
-      // if they didn't change buffer & length, initialize it
-      if(false) { //0 == twi_txBufferLength){
-        twi_txBufferLength = 1;
-        twi_txBuffer[0] = 0x00;
-      }
-	  else
-	  {
-		  break;
-	  }
-      // transmit first byte from buffer, fall
-    case TW_ST_DATA_ACK: // byte sent, ack returned
+	  break;
+	  
+	case TW_ST_DATA_ACK: // byte sent, ack returned
       // copy data to output register
       TWDR = twi_txBuffer[twi_txBufferIndex++];
 
@@ -619,7 +608,7 @@ void ICACHE_RAM_ATTR twi_onTwipEvent(uint8_t status)
       twi_stop();
       break;
   }
-  digitalWrite(13, LOW);
+  //digitalWrite(13, LOW);
 }
 
 void ICACHE_RAM_ATTR onSclChange(void)
@@ -633,7 +622,7 @@ void ICACHE_RAM_ATTR onSclChange(void)
 	sda	= SDA_READ();
 	scl = SCL_READ();
 	
-	digitalWrite(12, scl);
+	//digitalWrite(12, scl);
 	//digitalWrite(14, LOW);
 	
 	twip_status = 0xF8;		// reset TWI status
@@ -793,7 +782,7 @@ void ICACHE_RAM_ATTR onSdaChange(void)
 	sda	= SDA_READ();
 	scl = SCL_READ();
 	
-	digitalWrite(2, sda);
+	//digitalWrite(2, sda);
 	
 	switch (twip_state)
 	{
@@ -806,9 +795,9 @@ void ICACHE_RAM_ATTR onSdaChange(void)
 				// START
 				bitCount = 8;
 				twip_state = TWIP_START;
-				digitalWrite(14, HIGH);
+				//digitalWrite(14, HIGH);
 				ets_timer_arm_new(&timer, twi_timeout_ms, false, true); // Once, ms
-				digitalWrite(14, LOW);
+				//digitalWrite(14, LOW);
 			}
 			break;
 			

--- a/cores/esp8266/core_esp8266_si2c.c
+++ b/cores/esp8266/core_esp8266_si2c.c
@@ -579,7 +579,7 @@ void ICACHE_RAM_ATTR twi_onTwipEvent(uint8_t status)
       // request for txBuffer to be filled and length to be set
       // note: user must call twi_transmit(bytes, length) to do this
       //twi_onSlaveTransmit();
-	  ets_post(TASK_QUEUE_PRIO, TWI_SIG_TX, 0);
+	  ets_post(EVENTTASK_QUEUE_PRIO, TWI_SIG_TX, 0);
 
       // if they didn't change buffer & length, initialize it
       if(false) { //0 == twi_txBufferLength){

--- a/cores/esp8266/twi.h
+++ b/cores/esp8266/twi.h
@@ -17,6 +17,8 @@
   You should have received a copy of the GNU Lesser General Public
   License along with this library; if not, write to the Free Software
   Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+
+  Modified January 2017 by Bjorn Hammarberg (bjoham@esp8266.com) - i2c slave support
 */
 #ifndef SI2C_h
 #define SI2C_h
@@ -32,13 +34,27 @@ extern "C" {
 #define I2C_SDA_HELD_LOW            3
 #define I2C_SDA_HELD_LOW_AFTER_INIT 4
 
+#ifndef TWI_BUFFER_LENGTH
+#define TWI_BUFFER_LENGTH 32
+#endif
+
 void twi_init(unsigned char sda, unsigned char scl);
+void twi_setAddress(uint8_t);
 void twi_stop(void);
 void twi_setClock(unsigned int freq);
 void twi_setClockStretchLimit(uint32_t limit);
 uint8_t twi_writeTo(unsigned char address, unsigned char * buf, unsigned int len, unsigned char sendStop);
 uint8_t twi_readFrom(unsigned char address, unsigned char * buf, unsigned int len, unsigned char sendStop);
 uint8_t twi_status();
+
+uint8_t twi_transmit(const uint8_t*, uint8_t);
+
+void twi_attachSlaveRxEvent( void (*)(uint8_t*, int) );
+void twi_attachSlaveTxEvent( void (*)(void) );
+void twi_reply(uint8_t);
+//void twi_stop(void);
+void twi_releaseBus(void);
+
 
 #ifdef __cplusplus
 }

--- a/cores/esp8266/twi_util.h
+++ b/cores/esp8266/twi_util.h
@@ -1,0 +1,243 @@
+/* Copyright (c) 2002, Marek Michalkiewicz
+   Copyright (c) 2005, 2007 Joerg Wunsch
+   All rights reserved.
+
+   Redistribution and use in source and binary forms, with or without
+   modification, are permitted provided that the following conditions are met:
+
+   * Redistributions of source code must retain the above copyright
+     notice, this list of conditions and the following disclaimer.
+
+   * Redistributions in binary form must reproduce the above copyright
+     notice, this list of conditions and the following disclaimer in
+     the documentation and/or other materials provided with the
+     distribution.
+
+   * Neither the name of the copyright holders nor the names of
+     contributors may be used to endorse or promote products derived
+     from this software without specific prior written permission.
+
+  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+  POSSIBILITY OF SUCH DAMAGE. 
+  
+  Modified January 2017 by Bjorn Hammarberg (bjoham@esp8266.com) - i2c slave support
+*/
+
+/* $Id$ */
+/* copied from: Id: avr/twi.h,v 1.4 2004/11/01 21:19:54 arcanum Exp */
+
+#ifndef _UTIL_TWI_H_
+#define _UTIL_TWI_H_ 1
+
+//#include <avr/io.h>
+
+/** \file */
+/** \defgroup util_twi <util/twi.h>: TWI bit mask definitions
+    \code #include <util/twi.h> \endcode
+
+    This header file contains bit mask definitions for use with
+    the AVR TWI interface.
+*/
+/** \name TWSR values
+
+  Mnemonics:
+  <br>TW_MT_xxx - master transmitter
+  <br>TW_MR_xxx - master receiver
+  <br>TW_ST_xxx - slave transmitter
+  <br>TW_SR_xxx - slave receiver
+  */
+
+/*@{*/
+/* Master */
+/** \ingroup util_twi
+    \def TW_START
+    start condition transmitted */
+#define TW_START		0x08
+
+/** \ingroup util_twi
+    \def TW_REP_START
+    repeated start condition transmitted */
+#define TW_REP_START		0x10
+
+/* Master Transmitter */
+/** \ingroup util_twi
+    \def TW_MT_SLA_ACK
+    SLA+W transmitted, ACK received */
+#define TW_MT_SLA_ACK		0x18
+
+/** \ingroup util_twi
+    \def TW_MT_SLA_NACK
+    SLA+W transmitted, NACK received */
+#define TW_MT_SLA_NACK		0x20
+
+/** \ingroup util_twi
+    \def TW_MT_DATA_ACK
+    data transmitted, ACK received */
+#define TW_MT_DATA_ACK		0x28
+
+/** \ingroup util_twi
+    \def TW_MT_DATA_NACK
+    data transmitted, NACK received */
+#define TW_MT_DATA_NACK		0x30
+
+/** \ingroup util_twi
+    \def TW_MT_ARB_LOST
+    arbitration lost in SLA+W or data */
+#define TW_MT_ARB_LOST		0x38
+
+/* Master Receiver */
+/** \ingroup util_twi
+    \def TW_MR_ARB_LOST
+    arbitration lost in SLA+R or NACK */
+#define TW_MR_ARB_LOST		0x38
+
+/** \ingroup util_twi
+    \def TW_MR_SLA_ACK
+    SLA+R transmitted, ACK received */
+#define TW_MR_SLA_ACK		0x40
+
+/** \ingroup util_twi
+    \def TW_MR_SLA_NACK
+    SLA+R transmitted, NACK received */
+#define TW_MR_SLA_NACK		0x48
+
+/** \ingroup util_twi
+    \def TW_MR_DATA_ACK
+    data received, ACK returned */
+#define TW_MR_DATA_ACK		0x50
+
+/** \ingroup util_twi
+    \def TW_MR_DATA_NACK
+    data received, NACK returned */
+#define TW_MR_DATA_NACK		0x58
+
+/* Slave Transmitter */
+/** \ingroup util_twi
+    \def TW_ST_SLA_ACK
+    SLA+R received, ACK returned */
+#define TW_ST_SLA_ACK		0xA8
+
+/** \ingroup util_twi
+    \def TW_ST_ARB_LOST_SLA_ACK
+    arbitration lost in SLA+RW, SLA+R received, ACK returned */
+#define TW_ST_ARB_LOST_SLA_ACK	0xB0
+
+/** \ingroup util_twi
+    \def TW_ST_DATA_ACK
+    data transmitted, ACK received */
+#define TW_ST_DATA_ACK		0xB8
+
+/** \ingroup util_twi
+    \def TW_ST_DATA_NACK
+    data transmitted, NACK received */
+#define TW_ST_DATA_NACK		0xC0
+
+/** \ingroup util_twi
+    \def TW_ST_LAST_DATA
+    last data byte transmitted, ACK received */
+#define TW_ST_LAST_DATA		0xC8
+
+/* Slave Receiver */
+/** \ingroup util_twi
+    \def TW_SR_SLA_ACK
+    SLA+W received, ACK returned */
+#define TW_SR_SLA_ACK		0x60
+
+/** \ingroup util_twi
+    \def TW_SR_ARB_LOST_SLA_ACK
+    arbitration lost in SLA+RW, SLA+W received, ACK returned */
+#define TW_SR_ARB_LOST_SLA_ACK	0x68
+
+/** \ingroup util_twi
+    \def TW_SR_GCALL_ACK
+    general call received, ACK returned */
+#define TW_SR_GCALL_ACK		0x70
+
+/** \ingroup util_twi
+    \def TW_SR_ARB_LOST_GCALL_ACK
+    arbitration lost in SLA+RW, general call received, ACK returned */
+#define TW_SR_ARB_LOST_GCALL_ACK 0x78
+
+/** \ingroup util_twi
+    \def TW_SR_DATA_ACK
+    data received, ACK returned */
+#define TW_SR_DATA_ACK		0x80
+
+/** \ingroup util_twi
+    \def TW_SR_DATA_NACK
+    data received, NACK returned */
+#define TW_SR_DATA_NACK		0x88
+
+/** \ingroup util_twi
+    \def TW_SR_GCALL_DATA_ACK
+    general call data received, ACK returned */
+#define TW_SR_GCALL_DATA_ACK	0x90
+
+/** \ingroup util_twi
+    \def TW_SR_GCALL_DATA_NACK
+    general call data received, NACK returned */
+#define TW_SR_GCALL_DATA_NACK	0x98
+
+/** \ingroup util_twi
+    \def TW_SR_STOP
+    stop or repeated start condition received while selected */
+#define TW_SR_STOP		0xA0
+
+/* Misc */
+/** \ingroup util_twi
+    \def TW_NO_INFO
+    no state information available */
+#define TW_NO_INFO		0xF8
+
+/** \ingroup util_twi
+    \def TW_BUS_ERROR
+    illegal start or stop condition */
+#define TW_BUS_ERROR		0x00
+
+#if 0
+
+/**
+ * \ingroup util_twi
+ * \def TW_STATUS_MASK
+ * The lower 3 bits of TWSR are reserved on the ATmega163.
+ * The 2 LSB carry the prescaler bits on the newer ATmegas.
+ */
+#define TW_STATUS_MASK		(_BV(TWS7)|_BV(TWS6)|_BV(TWS5)|_BV(TWS4)|\
+				_BV(TWS3))
+/**
+ * \ingroup util_twi
+ * \def TW_STATUS
+ *
+ * TWSR, masked by TW_STATUS_MASK
+ */
+#define TW_STATUS		(TWSR & TW_STATUS_MASK)
+/*@}*/
+#endif
+
+
+/**
+ * \name R/~W bit in SLA+R/W address field.
+ */
+
+/*@{*/
+/** \ingroup util_twi
+    \def TW_READ
+    SLA+R address */
+#define TW_READ		1
+
+/** \ingroup util_twi
+    \def TW_WRITE
+    SLA+W address */
+#define TW_WRITE	0
+/*@}*/
+
+#endif  /* _UTIL_TWI_H_ */

--- a/libraries/Wire/Wire.cpp
+++ b/libraries/Wire/Wire.cpp
@@ -19,6 +19,7 @@
   Modified 2012 by Todd Krein (todd@krein.org) to implement repeated starts
   Modified December 2014 by Ivan Grokhotkov (ivan@esp8266.com) - esp8266 support
   Modified April 2015 by Hrsto Gochkov (ficeto@ficeto.com) - alternative esp8266 support
+  Modified January 2017 by Bjorn Hammarberg (bjoham@esp8266.com) - i2c slave support
 */
 
 extern "C" {
@@ -71,9 +72,9 @@ void TwoWire::begin(void){
 }
 
 void TwoWire::begin(uint8_t address){
-  // twi_setAddress(address);
-  // twi_attachSlaveTxEvent(onRequestService);
-  // twi_attachSlaveRxEvent(onReceiveService);
+  twi_setAddress(address);
+  twi_attachSlaveTxEvent(onRequestService);
+  twi_attachSlaveRxEvent(onReceiveService);
   begin();
 }
 
@@ -152,7 +153,7 @@ size_t TwoWire::write(uint8_t data){
     ++txBufferIndex;
     txBufferLength = txBufferIndex;
   } else {
-    // i2c_slave_transmit(&data, 1);
+    twi_transmit(&data, 1);
   }
   return 1;
 }
@@ -163,7 +164,7 @@ size_t TwoWire::write(const uint8_t *data, size_t quantity){
       if(!write(data[i])) return i;
     }
   }else{
-    // i2c_slave_transmit(data, quantity);
+    twi_transmit(data, quantity);
   }
   return quantity;
 }
@@ -207,46 +208,52 @@ void TwoWire::flush(void){
 void TwoWire::onReceiveService(uint8_t* inBytes, int numBytes)
 {
   // don't bother if user hasn't registered a callback
-  // if(!user_onReceive){
-  //   return;
-  // }
+  if (!user_onReceive) {
+	return;
+  }
   // // don't bother if rx buffer is in use by a master requestFrom() op
   // // i know this drops data, but it allows for slight stupidity
   // // meaning, they may not have read all the master requestFrom() data yet
   // if(rxBufferIndex < rxBufferLength){
   //   return;
   // }
-  // // copy twi rx buffer into local read buffer
-  // // this enables new reads to happen in parallel
-  // for(uint8_t i = 0; i < numBytes; ++i){
-  //   rxBuffer[i] = inBytes[i];
-  // }
-  // // set rx iterator vars
-  // rxBufferIndex = 0;
-  // rxBufferLength = numBytes;
-  // // alert user program
-  // user_onReceive(numBytes);
+  
+  // copy twi rx buffer into local read buffer
+  // this enables new reads to happen in parallel
+  for (uint8_t i = 0; i < numBytes; ++i) {
+	rxBuffer[i] = inBytes[i];
+  }
+  
+  // set rx iterator vars
+  rxBufferIndex = 0;
+  rxBufferLength = numBytes;
+  
+  // alert user program
+  user_onReceive(numBytes);
 }
 
-void TwoWire::onRequestService(void){
-  // // don't bother if user hasn't registered a callback
-  // if(!user_onRequest){
-  //   return;
-  // }
-  // // reset tx buffer iterator vars
-  // // !!! this will kill any pending pre-master sendTo() activity
-  // txBufferIndex = 0;
-  // txBufferLength = 0;
-  // // alert user program
-  // user_onRequest();
+void TwoWire::onRequestService(void)
+{
+	// don't bother if user hasn't registered a callback
+	if (!user_onRequest) {
+		return;
+	}
+	
+	// reset tx buffer iterator vars
+	// !!! this will kill any pending pre-master sendTo() activity
+	txBufferIndex = 0;
+	txBufferLength = 0;
+	
+	// alert user program
+	user_onRequest();
 }
 
-void TwoWire::onReceive( void (*function)(int) ){
-  //user_onReceive = function;
+void TwoWire::onReceive( void (*function)(int) ) {
+  user_onReceive = function;
 }
 
 void TwoWire::onRequest( void (*function)(void) ){
-  //user_onRequest = function;
+  user_onRequest = function;
 }
 
 // Preinstantiate Objects //////////////////////////////////////////////////////


### PR DESCRIPTION
Adding i2c-slave support
- requires interrupts
- requires clock less than 15 kHz (not supported through Arduino API)
- uses clock stretching but not all Arduino SDKs support it because of faulty implementations